### PR TITLE
Introduce golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,0 +1,11 @@
+## SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+##
+## SPDX-License-Identifier: MIT
+
+[run]
+go = "1.16"
+tests = true
+
+[linters]
+enable = ["stylecheck", "whitespace", "containedctx", "contextcheck", "decorder",
+    "errname", "errorlint", "gofmt", "gofumpt"]

--- a/subject_capitalize/subject_capitalize_test.go
+++ b/subject_capitalize/subject_capitalize_test.go
@@ -7,10 +7,11 @@ package subcap
 import (
 	"bytes"
 	"fmt"
-	"github.com/wneessen/go-mail"
-	"golang.org/x/text/language"
 	"strings"
 	"testing"
+
+	"github.com/wneessen/go-mail"
+	"golang.org/x/text/language"
 )
 
 func TestNew(t *testing.T) {

--- a/subject_capitalize/subject_capitalize_test.go
+++ b/subject_capitalize/subject_capitalize_test.go
@@ -6,7 +6,6 @@ package subcap
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -16,8 +15,8 @@ import (
 
 func TestNew(t *testing.T) {
 	mw := New(language.English)
-	if fmt.Sprintf("%s", mw.l) != "en" {
-		t.Errorf("New() failed. Expected language: %q, got: %q", "en", fmt.Sprintf("%s", mw.l))
+	if mw.l.String() != "en" {
+		t.Errorf("New() failed. Expected language: %q, got: %q", "en", mw.l.String())
 	}
 }
 


### PR DESCRIPTION
Let's introduce some linting rules, so PRs are more conformant to the already used code style