### PR TITLE
Fix the Middleware interface due to the changes in go-mail v0.3.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ module github.com/wneessen/go-mail-middleware
 go 1.16
 
 require (
-	github.com/wneessen/go-mail v0.3.2
+	github.com/wneessen/go-mail v0.3.3
 	golang.org/x/text v0.4.0
 )

--- a/subject_capitalize/subject_capitalize.go
+++ b/subject_capitalize/subject_capitalize.go
@@ -15,6 +15,8 @@ type Middleware struct {
 	l language.Tag
 }
 
+const Type mail.MiddlewareType = "subcap"
+
 // New returns a new Middleware and can be used with the mail.WithMiddleware method. It takes a
 // language.Tag as input
 func New(l language.Tag) *Middleware {
@@ -30,4 +32,9 @@ func (c Middleware) Handle(m *mail.Msg) *mail.Msg {
 	cp := cases.Title(c.l)
 	m.Subject(cp.String(cs[0]))
 	return m
+}
+
+// Type returns the MiddlewareType for this Middleware
+func (c Middleware) Type() mail.MiddlewareType {
+	return Type
 }


### PR DESCRIPTION
Since go-mail v0.3.3, the Middleware interface requires a Type() method which this fix introduces