### PR TITLE
DKIM: Fix boundary for multipart emails

### DIFF
--- a/dkim/dkim.go
+++ b/dkim/dkim.go
@@ -76,12 +76,6 @@ func NewFromEd25519Key(k []byte, sc *SignerConfig) (*Middleware, error) {
 
 // Handle is the handler method that satisfies the mail.Middleware interface
 func (d Middleware) Handle(m *mail.Msg) *mail.Msg {
-	// If no boundary is set for the mail.Msg we need to set our own fixed boundary, otherwise
-	// a new boundary will bet generated after the middleware has been applied and therfore
-	// the body hash will be altered
-	if m.GetBoundary() == "" {
-		m.SetBoundary(randomBoundary())
-	}
 	ibuf := bytes.NewBuffer(nil)
 	_, err := m.WriteToSkipMiddleware(ibuf, Type)
 	if err != nil {


### PR DESCRIPTION
Apologies for #80, it was a bit premature. I found that the error continued to occur if one was signing multipart emails. The issue was that `SetBoundary` overrides all boundaries to be the same, which causes problems for nested multipart (e.g.  text/html email with attachments). The actual solution all along was to let *go-mail* manage the boundaries. Has this caused other issues in the past?